### PR TITLE
Fix bug flèche du bas

### DIFF
--- a/main.html
+++ b/main.html
@@ -433,7 +433,8 @@
         return  e.key == " " ||
                 e.code == "Space" ||      
                 e.keyCode == '32' || 
-                e.keyCode == '39'
+                e.keyCode == '39' ||
+                e.keyCode == '40'
     }
 
     document.addEventListener('keyup', (e) => {


### PR DESCRIPTION
L'option "Mauvaise réponse ARROW DOWN" marchait pas parce que la fonction `isMacro(e)` ne contenait pas le keyCode de keyDown